### PR TITLE
Update nbclient to version 0.5.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,14 +11,18 @@ source:
   sha256: ed7d18431393750d29a64da432e0b7889274eb5a5056682be5691b1b1dc8f755
 
 build:
+  skip: True  # [py<36]
   number: {{ build }}
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - wheel >=0.31.0
+    - setuptools >=38.6.0
+    - twine >=1.11.0
   run:
     - python >=3.6
     - traitlets >=4.2
@@ -28,8 +32,13 @@ requirements:
     - nest-asyncio
 
 test:
+  commands:
+    - pip check
   imports:
     - nbclient
+  requires:
+    - pip
+    - python <3.10
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nbclient" %}
-{% set version = "0.5.3" %}
+{% set version = "0.5.5" %}
 {% set build = 0 %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: db17271330c68c8c88d46d72349e24c147bb6f34ec82d8481a8f025c4d26589c
+  sha256: ed7d18431393750d29a64da432e0b7889274eb5a5056682be5691b1b1dc8f755
 
 build:
   number: {{ build }}


### PR DESCRIPTION

1. check the upstream
    https://github.com/jupyter/nbclient/tree/0.5.5

2. check the pinnings
    https://github.com/jupyter/nbclient/blob/0.5.5/tox.ini
    https://github.com/jupyter/nbclient/blob/0.5.5/setup.py
    https://github.com/jupyter/nbclient/blob/0.5.5/setup.cfg
    https://github.com/jupyter/nbclient/blob/0.5.5/requirements.txt
    https://github.com/jupyter/nbclient/blob/0.5.5/requirements-dev.txt
    https://github.com/jupyter/nbclient/blob/0.5.5/pyproject.toml

3. check changelogs
    https://github.com/jupyter/nbclient/blob/0.5.5/CHANGELOG.md

4. additional research
    https://github.com/conda-forge/nbclient-feedstock/issues
5. verify dev_url
    https://github.com/jupyter/nbclient
6. verify doc_url
    https://nbclient.readthedocs.io
7. added pip to the test section
8. verify the test section
9. additional tests

In order to test the `nbclient` package version `0.5.5` the following command was used:
`conda build nbclient-feedstock --test` 
The test result was the following:
`All tests passed`

Based on the research findings and on the test results we can conclude that it is safe to update `nbclient` to version `0.5.5`

